### PR TITLE
fix: bump kube-rbac-proxy sidecar v0.11.0 -> v0.13.1 (mirror-missing image)

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
## Problem

The auth-proxy sidecar is pinned to `gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0`, which is no longer available in our internal image mirror. On the cluster the sidecar goes into `ImagePullBackOff`, so the `controller-manager` pod stays **1/2 NotReady**.

Because the pod is NotReady, it is dropped from the webhook Service's endpoints. Since the `magesecret.kb.io` / `magekey.kb.io` webhooks are `failurePolicy: Fail`, every AgeSecret/AgeKey create/update/delete then fails with `no endpoints available`. That includes the operator removing its **own finalizers**, so deleted CRs get stuck `Terminating` indefinitely.

## Fix

Bump the sidecar to `v0.13.1` — the same image, already available in the mirror and pulling fine. This restores the sidecar, the pod becomes Ready, webhook endpoints return, and stuck finalizers drain on their own.

## Blast radius

Config-only, one-line image tag. No behaviour change to the operator itself.
